### PR TITLE
Make deprecated tags red.

### DIFF
--- a/dist/input-tag-highlight.user.js
+++ b/dist/input-tag-highlight.user.js
@@ -72,6 +72,7 @@ const SCRIPT_CSS = /* CSS */`
   }
   .tag-highlight-deprecated {
     text-decoration: line-through;
+    color: var(--artist-tag-color)!important;
   }
   .tag-highlight-meta-name {
     color: var(--tag-highlight-meta-name-color);


### PR DESCRIPTION
While gardening deprecated tags with the Input Tag Highlight Userscript, I kept thinking to myself, man I wish it was easier to tell which tags need to be replaced.